### PR TITLE
fix: handle null recipient names in email processing

### DIFF
--- a/backend/config/mongo_config.py
+++ b/backend/config/mongo_config.py
@@ -3,8 +3,10 @@ from dotenv import load_dotenv
 from .mongo_schema import (
     CONVERSATIONS_SCHEMA,
     INSIGHTS_SCHEMA,
+    EMAILS_SCHEMA,
     CONVERSATIONS_INDEXES,
-    INSIGHTS_INDEXES
+    INSIGHTS_INDEXES,
+    EMAILS_INDEXES
 )
 
 # Load environment variables
@@ -18,6 +20,7 @@ MONGO_DB_NAME = os.getenv('MONGO_DB_NAME', 'pm_copilot')
 # Collection names
 CONVERSATIONS_COLLECTION = 'conversations'
 INSIGHTS_COLLECTION = 'insights'
+EMAILS_COLLECTION = 'emails'
 
 # MongoDB connection options
 MONGO_OPTIONS = {
@@ -46,12 +49,24 @@ def init_collections(db):
         )
         print(f"Created collection: {INSIGHTS_COLLECTION}")
     
+    # Initialize emails collection
+    if EMAILS_COLLECTION not in db.list_collection_names():
+        db.create_collection(
+            EMAILS_COLLECTION,
+            **EMAILS_SCHEMA
+        )
+        print(f"Created collection: {EMAILS_COLLECTION}")
+    
     # Create indexes
     conversations = db[CONVERSATIONS_COLLECTION]
     insights = db[INSIGHTS_COLLECTION]
+    emails = db[EMAILS_COLLECTION]
     
     for index_config in CONVERSATIONS_INDEXES:
         conversations.create_index(**index_config)
     
     for index_config in INSIGHTS_INDEXES:
-        insights.create_index(**index_config) 
+        insights.create_index(**index_config)
+        
+    for index_config in EMAILS_INDEXES:
+        emails.create_index(**index_config) 

--- a/backend/config/mongo_schema.py
+++ b/backend/config/mongo_schema.py
@@ -278,6 +278,144 @@ INSIGHTS_SCHEMA = {
     }
 }
 
+# Schema for emails collection
+EMAILS_SCHEMA = {
+    "validator": {
+        "$jsonSchema": {
+            "bsonType": "object",
+            "required": ["email_id", "thread_id", "subject", "from_email", "date", "content"],
+            "properties": {
+                "email_id": {
+                    "bsonType": "string",
+                    "description": "Unique identifier for the email"
+                },
+                "thread_id": {
+                    "bsonType": "string",
+                    "description": "Reference to the conversation thread this email belongs to"
+                },
+                "subject": {
+                    "bsonType": "string",
+                    "description": "Email subject"
+                },
+                "from_email": {
+                    "bsonType": "object",
+                    "description": "Email sender information",
+                    "required": ["email", "name"],
+                    "properties": {
+                        "email": {
+                            "bsonType": "string",
+                            "description": "Sender's email address"
+                        },
+                        "name": {
+                            "bsonType": "string",
+                            "description": "Sender's name"
+                        }
+                    }
+                },
+                "to_emails": {
+                    "bsonType": "array",
+                    "items": {
+                        "bsonType": "object",
+                        "properties": {
+                            "email": {
+                                "bsonType": "string",
+                                "description": "Recipient's email address"
+                            },
+                            "name": {
+                                "bsonType": "string",
+                                "description": "Recipient's name"
+                            }
+                        }
+                    },
+                    "description": "List of email recipients"
+                },
+                "date": {
+                    "bsonType": "string",
+                    "description": "Email date in ISO format"
+                },
+                "content": {
+                    "bsonType": "object",
+                    "required": ["html", "text"],
+                    "properties": {
+                        "html": {
+                            "bsonType": "string",
+                            "description": "HTML content of the email"
+                        },
+                        "text": {
+                            "bsonType": "string",
+                            "description": "Plain text content of the email"
+                        }
+                    },
+                    "description": "Email content in both HTML and plain text formats"
+                },
+                "metadata": {
+                    "bsonType": "object",
+                    "description": "Additional metadata about the email",
+                    "properties": {
+                        "source": {
+                            "bsonType": "string",
+                            "enum": ["POSTMARK", "CMS", "VEYRA"],
+                            "description": "Source system of the email"
+                        },
+                        "template_name": {
+                            "bsonType": "string",
+                            "description": "Template name or ID if applicable"
+                        },
+                        "tags": {
+                            "bsonType": "array",
+                            "items": {
+                                "bsonType": "string"
+                            },
+                            "description": "Tags associated with the email"
+                        },
+                        "summary": {
+                            "bsonType": "string",
+                            "description": "AI-generated summary of the email content"
+                        }
+                    }
+                },
+                "created_at": {
+                    "bsonType": "int",
+                    "description": "Unix timestamp when the email was first stored"
+                },
+                "updated_at": {
+                    "bsonType": "int",
+                    "description": "Unix timestamp when the email was last updated"
+                }
+            }
+        }
+    }
+}
+
+# Index configurations for emails collection
+EMAILS_INDEXES = [
+    {
+        "keys": [("email_id", 1)],
+        "name": "email_id_idx",
+        "unique": True
+    },
+    {
+        "keys": [("thread_id", 1)],
+        "name": "thread_id_idx"
+    },
+    {
+        "keys": [("date", -1)],
+        "name": "date_idx"
+    },
+    {
+        "keys": [("from_email.email", 1)],
+        "name": "from_email_idx"
+    },
+    {
+        "keys": [("metadata.tags", 1)],
+        "name": "tags_idx"
+    },
+    {
+        "keys": [("created_at", -1)],
+        "name": "created_at_idx"
+    }
+]
+
 # Index configurations
 CONVERSATIONS_INDEXES = [
     {

--- a/backend/models/email.py
+++ b/backend/models/email.py
@@ -1,0 +1,119 @@
+from datetime import datetime
+from utils.mongo_client import get_collection, get_db
+from config.mongo_config import EMAILS_COLLECTION
+import time
+import uuid
+
+class Email:
+    def __init__(self, email_id=None, thread_id=None, subject=None, from_email=None, to_emails=None,
+                 date=None, content=None, metadata=None):
+        self.email_id = email_id or str(uuid.uuid4())
+        self.thread_id = thread_id
+        self.subject = subject
+        self.from_email = from_email
+        self.to_emails = to_emails or []
+        self.date = date
+        self.content = content or {"html": "", "text": ""}
+        self.metadata = metadata or {}
+        self.created_at = int(time.time())
+        self.updated_at = int(time.time())
+        self.collection = get_collection(EMAILS_COLLECTION)
+
+    def save(self):
+        """Save email to MongoDB with validation"""
+        email_data = {
+            'email_id': self.email_id,
+            'thread_id': self.thread_id,
+            'subject': self.subject,
+            'from_email': self.from_email,
+            'to_emails': self.to_emails,
+            'date': self.date,
+            'content': self.content,
+            'metadata': self.metadata,
+            'created_at': self.created_at,
+            'updated_at': self.updated_at
+        }
+        
+        # Update if exists, insert if not
+        result = self.collection.update_one(
+            {'email_id': self.email_id},
+            {'$set': email_data},
+            upsert=True
+        )
+        return result.upserted_id or self.email_id
+
+    @classmethod
+    def get_by_id(cls, email_id):
+        """Get email by its ID"""
+        collection = get_collection(EMAILS_COLLECTION)
+        return collection.find_one({'email_id': email_id})
+
+    @classmethod
+    def get_by_thread_id(cls, thread_id):
+        """Get all emails in a thread"""
+        collection = get_collection(EMAILS_COLLECTION)
+        return list(collection.find({'thread_id': thread_id}).sort('date', -1))
+
+    @classmethod
+    def get_by_sender(cls, email):
+        """Get all emails from a specific sender"""
+        collection = get_collection(EMAILS_COLLECTION)
+        return list(collection.find({'from_email.email': email}).sort('date', -1))
+
+    @classmethod
+    def get_by_tags(cls, tags):
+        """Get emails by tags"""
+        collection = get_collection(EMAILS_COLLECTION)
+        return list(collection.find({'metadata.tags': {'$in': tags}}).sort('date', -1))
+
+    @classmethod
+    def add_tag(cls, email_id, tag):
+        """Add a tag to an email"""
+        collection = get_collection(EMAILS_COLLECTION)
+        return collection.update_one(
+            {'email_id': email_id},
+            {
+                '$addToSet': {'metadata.tags': tag},
+                '$set': {'updated_at': int(time.time())}
+            }
+        )
+
+    @classmethod
+    def remove_tag(cls, email_id, tag):
+        """Remove a tag from an email"""
+        collection = get_collection(EMAILS_COLLECTION)
+        return collection.update_one(
+            {'email_id': email_id},
+            {
+                '$pull': {'metadata.tags': tag},
+                '$set': {'updated_at': int(time.time())}
+            }
+        )
+
+    @classmethod
+    def update_summary(cls, email_id, summary):
+        """Update the AI-generated summary of an email"""
+        collection = get_collection(EMAILS_COLLECTION)
+        return collection.update_one(
+            {'email_id': email_id},
+            {
+                '$set': {
+                    'metadata.summary': summary,
+                    'updated_at': int(time.time())
+                }
+            }
+        )
+
+    @classmethod
+    def delete(cls, email_id):
+        """Delete an email"""
+        collection = get_collection(EMAILS_COLLECTION)
+        result = collection.delete_one({'email_id': email_id})
+        return result.deleted_count > 0
+
+    @classmethod
+    def bulk_delete(cls, email_ids):
+        """Delete multiple emails"""
+        collection = get_collection(EMAILS_COLLECTION)
+        result = collection.delete_many({'email_id': {'$in': email_ids}})
+        return result.deleted_count 


### PR DESCRIPTION
- Add proper handling of null recipient names in to_emails field\n- Generate names from email addresses when names are missing\n- Ensure all recipients have both email and name fields as strings\n- Fix MongoDB validation error for email documents