### PR TITLE
Implement date-based email pagination to replace pageToken

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -50,6 +50,12 @@ class Conversation:
         if self.insight_id:
             message['insight_id'] = self.insight_id
 
+        # Add pagination fields if they exist in metadata
+        if self.metadata:
+            for field in ['tool_original_query_params', 'tool_current_offset', 'tool_limit_per_page', 'tool_total_emails_available', 'tool_has_more']:
+                if field in self.metadata:
+                    message[field] = self.metadata[field]
+
         if 'emails' in self.tool_results and self.tool_results['emails']:
             processed_email_ids = []
             emails_collection = get_collection(EMAILS_COLLECTION)

--- a/backend/utils/date_parser.py
+++ b/backend/utils/date_parser.py
@@ -9,20 +9,45 @@ def parse_email_date(date_str: str) -> datetime:
     Parses an email date string into a timezone-aware datetime object.
     
     Args:
-        date_str: The date string from the email (e.g., "Tue, 24 Jun 2025 11:52:24 GMT").
+        date_str: The date string from the email (e.g., "Tue, 24 Jun 2025 11:52:24 GMT" or Unix timestamp).
 
     Returns:
         A datetime object. Returns a minimum default date if parsing fails.
     """
     if not date_str:
         return MIN_DATE
+    
+    # Try parsing as Unix timestamp first (Composio format)
     try:
-        # parsedate_to_datetime handles various email date formats
+        # Check if it's a numeric timestamp (string or number)
+        if isinstance(date_str, (int, float)) or (isinstance(date_str, str) and date_str.isdigit()):
+            timestamp = float(date_str)
+            # Handle both seconds and milliseconds timestamps
+            if timestamp > 1e10:  # Milliseconds timestamp
+                timestamp = timestamp / 1000
+            dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+            return dt
+    except (ValueError, TypeError, OSError):
+        pass
+    
+    # Try parsing as RFC 2822 format (standard email date)
+    try:
         dt = parsedate_to_datetime(date_str)
         # If the datetime object is naive, assume it's UTC, which is common for email headers.
         if dt.tzinfo is None:
             return dt.replace(tzinfo=timezone.utc)
         return dt
-    except (TypeError, ValueError) as e:
-        print(f"[WARNING] Could not parse date string '{date_str}': {e}")
-        return MIN_DATE 
+    except (TypeError, ValueError):
+        pass
+    
+    # Try parsing as ISO format
+    try:
+        dt = datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        pass
+    
+    print(f"[WARNING] Could not parse date string '{date_str}': trying all formats failed")
+    return MIN_DATE 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -440,11 +440,41 @@ function App() {
   };
 
   // Render message content with proper formatting
+  const handleUpdateMessage = (messageId, updatedResults, paginationData) => {
+    setMessages(prevMessages => 
+      prevMessages.map(msg => {
+        if (msg.id === messageId) {
+          const updatedMessage = {
+            ...msg,
+            tool_results: updatedResults
+          };
+          
+          // Update pagination data if provided
+          if (paginationData) {
+            updatedMessage.tool_current_offset = paginationData.currentOffset;
+            updatedMessage.tool_limit_per_page = paginationData.limitPerPage;
+            updatedMessage.tool_total_emails_available = paginationData.totalEmailsAvailable;
+            updatedMessage.tool_has_more = paginationData.hasMore;
+          }
+          
+          return updatedMessage;
+        }
+        return msg;
+      })
+    );
+  };
+
   const renderMessage = (message, onNewMessage) => {
     console.log('renderMessage called with full message:', message );
     console.log('renderMessage - tool_results:', message.tool_results);
-    console.log('renderMessage - tool_current_offset:', message.tool_current_offset);
-    console.log('renderMessage - condition check:', (message.tool_results || message.tool_current_offset !== undefined));
+                console.log('renderMessage - tool_current_offset:', message.tool_current_offset);
+            console.log('renderMessage - condition check:', (message.tool_results || message.tool_current_offset !== undefined));
+            console.log('renderMessage - pagination props to pass:', {
+              currentOffset: message.tool_current_offset,
+              limitPerPage: message.tool_limit_per_page,
+              totalEmailsAvailable: message.tool_total_emails_available,
+              hasMore: message.tool_has_more
+            });
     
     return (
       <Box sx={{ mb: 0 }}>
@@ -458,7 +488,13 @@ function App() {
               threadId={threadId} // threadId is available in App.js scope
               messageId={message.id} // assistant's message_id
               onNewMessageReceived={onNewMessage}
+              onUpdate={handleUpdateMessage}
               showSnackbar={showSnackbar}
+              // Pass pagination props
+              currentOffset={message.tool_current_offset}
+              limitPerPage={message.tool_limit_per_page}
+              totalEmailsAvailable={message.tool_total_emails_available}
+              hasMore={message.tool_has_more}
             />
           </Box>
         )}

--- a/frontend/src/components/VeyraResults.css
+++ b/frontend/src/components/VeyraResults.css
@@ -220,6 +220,48 @@
   justify-content: flex-end;
 }
 
+.load-more-row {
+  justify-content: center;
+  padding: 16px;
+  border-top: 1px solid #f0f0f0;
+  background-color: #fafafa;
+}
+
+.load-more-row:hover {
+  background-color: #fafafa;
+}
+
+.load-more-content {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.load-more-btn {
+  background: none;
+  border: none;
+  color: #1976d2;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 8px 16px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.load-more-btn:hover {
+  background-color: #e3f2fd;
+}
+
+.load-more-btn:disabled {
+  color: #999;
+  cursor: not-allowed;
+}
+
+.load-more-btn:disabled:hover {
+  background-color: transparent;
+}
+
 .hover-icon-btn {
   background: none;
   border: 1px solid #ccc;


### PR DESCRIPTION
- Replace Gmail API pageToken pagination with date-based chronological pagination
- Use 'before:YYYY/MM/DD' Gmail query syntax for consistent chronological ordering
- Fix issue where pageToken returned emails from random time periods
- Update ComposioService.get_recent_emails() to use oldest email date as next page token
- Maintain compatibility with existing pagination metadata structure
- Add proper date parsing and Gmail date format conversion

Known issue: Query construction still needs refinement for load_more_emails endpoint