### PR TITLE
feat: Add email sidebar reading pane with Gmail-like UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.8.2",
+        "dompurify": "^3.2.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.6.0",
@@ -6744,6 +6745,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.8.2",
+    "dompurify": "^3.2.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.6.0",

--- a/frontend/src/components/EmailSidebar.js
+++ b/frontend/src/components/EmailSidebar.js
@@ -1,0 +1,223 @@
+import React from 'react';
+import {
+  Drawer,
+  Box,
+  Typography,
+  IconButton,
+  Divider,
+  Paper,
+  CircularProgress,
+  Alert
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import PersonIcon from '@mui/icons-material/Person';
+import SubjectIcon from '@mui/icons-material/Subject';
+import DateRangeIcon from '@mui/icons-material/DateRange';
+import DOMPurify from 'dompurify';
+
+const EmailSidebar = ({ 
+  open, 
+  email, 
+  loading, 
+  error, 
+  onClose
+}) => {
+  
+  // Check if mobile using React state for responsive updates
+  const [isMobile, setIsMobile] = React.useState(window.innerWidth < 768);
+
+  React.useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  
+  const formatDate = (dateString) => {
+    if (!dateString) return 'Unknown Date';
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleString('en-US', {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+      });
+    } catch (error) {
+      return dateString;
+    }
+  };
+
+  const sanitizeHTML = (html) => {
+    return DOMPurify.sanitize(html, {
+      ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'a', 'div', 'span', 'table', 'tr', 'td', 'th', 'thead', 'tbody'],
+      ALLOWED_ATTR: ['href', 'target', 'style'],
+      ALLOW_DATA_ATTR: false
+    });
+  };
+
+  const renderEmailBody = () => {
+    if (!email || !email.content) return null;
+
+    const { html, text } = email.content;
+    
+    // Prefer HTML content if available, otherwise use text
+    if (html && html.trim()) {
+      return (
+        <Box
+          dangerouslySetInnerHTML={{
+            __html: sanitizeHTML(html)
+          }}
+          sx={{
+            '& img': { maxWidth: '100%', height: 'auto' },
+            '& a': { color: 'primary.main' },
+            '& table': { width: '100%', borderCollapse: 'collapse' },
+            '& td, & th': { padding: '8px', borderBottom: '1px solid #eee' },
+            lineHeight: 1.6,
+            fontSize: '14px'
+          }}
+        />
+      );
+    } else if (text && text.trim()) {
+      return (
+        <Typography
+          variant="body2"
+          component="pre"
+          sx={{
+            whiteSpace: 'pre-wrap',
+            fontFamily: 'inherit',
+            fontSize: '14px',
+            lineHeight: 1.6,
+            wordBreak: 'break-word'
+          }}
+        >
+          {text}
+        </Typography>
+      );
+    } else {
+      return (
+        <Typography variant="body2" color="text.secondary">
+          No content available
+        </Typography>
+      );
+    }
+  };
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      variant="temporary" // Always temporary for overlay behavior
+      sx={{
+        zIndex: 1300, // Higher than main content
+        '& .MuiDrawer-paper': {
+          width: isMobile ? '100%' : '60%', // 60% of viewport width on desktop
+          boxSizing: 'border-box',
+          backgroundColor: '#f8f9fa',
+          borderLeft: isMobile ? 'none' : '1px solid #dee2e6',
+          height: '100vh',
+          position: 'fixed',
+          top: 0,
+          right: 0,
+        },
+      }}
+    >
+      <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', height: '100%' }}>
+        {/* Header with close button */}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            Email
+          </Typography>
+          <IconButton onClick={onClose} size="small">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        {/* Content */}
+        <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
+          {loading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+              <CircularProgress />
+            </Box>
+          )}
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          {email && !loading && !error && (
+            <Paper elevation={0} sx={{ p: 2, backgroundColor: 'white', borderRadius: 2 }}>
+              {/* Subject */}
+              <Box sx={{ mb: 2 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                  <SubjectIcon sx={{ fontSize: 16, mr: 1, color: 'text.secondary' }} />
+                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', fontWeight: 600 }}>
+                    Subject
+                  </Typography>
+                </Box>
+                <Typography variant="h6" sx={{ fontWeight: 500, mb: 1 }}>
+                  {email.subject || 'No Subject'}
+                </Typography>
+              </Box>
+
+              <Divider sx={{ mb: 2 }} />
+
+              {/* From */}
+              <Box sx={{ mb: 2 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                  <PersonIcon sx={{ fontSize: 16, mr: 1, color: 'text.secondary' }} />
+                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', fontWeight: 600 }}>
+                    From
+                  </Typography>
+                </Box>
+                <Typography variant="body2">
+                  {email.from_email?.name || 'Unknown Sender'}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {email.from_email?.email || 'unknown@unknown.com'}
+                </Typography>
+              </Box>
+
+              <Divider sx={{ mb: 2 }} />
+
+              {/* Date */}
+              <Box sx={{ mb: 2 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                  <DateRangeIcon sx={{ fontSize: 16, mr: 1, color: 'text.secondary' }} />
+                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', fontWeight: 600 }}>
+                    Date
+                  </Typography>
+                </Box>
+                <Typography variant="body2">
+                  {formatDate(email.date)}
+                </Typography>
+              </Box>
+
+              <Divider sx={{ mb: 2 }} />
+
+              {/* Body */}
+              <Box>
+                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', fontWeight: 600, mb: 1, display: 'block' }}>
+                  Message
+                </Typography>
+                <Box sx={{ mt: 1 }}>
+                  {renderEmailBody()}
+                </Box>
+              </Box>
+            </Paper>
+          )}
+        </Box>
+      </Box>
+    </Drawer>
+  );
+};
+
+export default EmailSidebar; 


### PR DESCRIPTION
- Add EmailSidebar component with Gmail-like reading pane layout
- Implement middle icon click to open emails in right sidebar (60% width)
- Add HTML content rendering with DOMPurify sanitization for security
- Support both HTML and text email content with automatic fetching
- Create overlay sidebar that doesn't squeeze main content
- Add responsive design: full-screen on mobile, overlay on desktop
- Fix email list interaction issues (hover/selection per individual email)
- Add closeable sidebar with X button and click-outside-to-close
- Ensure single sidebar instance (new email replaces current content)
- Add proper error handling and loading states
- Install DOMPurify dependency for safe HTML rendering

Technical improvements:
- Robust React key generation to prevent state conflicts
- Enhanced event handling for email list interactions
- Mobile-responsive sidebar behavior with auto-close thread sidebar
- Overlay positioning with proper z-index management
- Content fetching integration with existing /get_email_content endpoint