### PR TITLE
Fix email thread ID extraction from Composio API response

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -695,7 +695,7 @@ def chat():
                                 }
                                 
                                 # Extract Gmail thread ID from Composio response
-                                gmail_thread_id = composio_email.get('threadId', '')
+                                gmail_thread_id = composio_email.get('thread_id') or composio_email.get('threadId', '')
                                 
                                 # Create Email model instance
                                 email_doc = Email(
@@ -2011,7 +2011,7 @@ def load_more_emails():
                         from_email = {'email': sender_raw.strip(), 'name': sender_raw.split('@')[0]}
                 
                 # Extract Gmail thread ID from Composio response
-                gmail_thread_id = email.get('threadId', '')
+                gmail_thread_id = email.get('thread_id') or email.get('threadId', '')
                 
                 formatted_email = {
                     'email_id': email_id.strip(),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -65,7 +65,7 @@ def mock_composio_service():
                     'messages': [
                         {
                             'messageId': '198efca4a33ef48d',
-                            'threadId': 'thread_123',
+                            'thread_id': 'thread_123',
                             'subject': 'Test Email Subject',
                             'messageText': 'Test email content',
                             'date': '1640995200',  # Unix timestamp
@@ -76,7 +76,7 @@ def mock_composio_service():
                         },
                         {
                             'messageId': '298efca4a33ef48e',
-                            'threadId': 'thread_124',
+                            'thread_id': 'thread_124',
                             'subject': 'Another Test Email',
                             'messageText': 'Another test email content',
                             'date': '1640995300',

--- a/backend/tests/test_email_count_verification.py
+++ b/backend/tests/test_email_count_verification.py
@@ -39,7 +39,7 @@ class TestEmailCountVerification:
         for i in range(expected_count):
             test_emails.append({
                 'messageId': f'test_email_{i}',
-                'threadId': f'thread_{i}',
+                'thread_id': f'thread_{i}',
                 'subject': f'Test Email {i}',
                 'messageText': f'Content of test email {i}',
                 'date': str(1640995200 + i * 1000),
@@ -80,8 +80,8 @@ class TestEmailCountVerification:
                 # Create Email model instance (simplified version of app.py logic)
                 email_doc = Email(
                     email_id=email_id,
-                    thread_id=composio_email.get('threadId'),
-                    gmail_thread_id=composio_email.get('threadId'),
+                    thread_id=composio_email.get('thread_id'),
+                    gmail_thread_id=composio_email.get('thread_id'),
                     subject=composio_email.get('subject'),
                     from_email={'email': composio_email.get('from', {}).get('email', ''), 
                               'name': composio_email.get('from', {}).get('name', '')},
@@ -146,7 +146,7 @@ class TestEmailCountVerification:
         for i in range(large_batch_size):
             test_emails.append({
                 'messageId': f'large_batch_email_{i:03d}',
-                'threadId': f'large_thread_{i:03d}',
+                'thread_id': f'large_thread_{i:03d}',
                 'subject': f'Large Batch Email {i:03d}',
                 'messageText': f'Content {i:03d}',
                 'date': str(1640995200 + i),
@@ -180,8 +180,8 @@ class TestEmailCountVerification:
             for composio_email in messages_data:
                 email_doc = Email(
                     email_id=composio_email.get('messageId'),
-                    thread_id=composio_email.get('threadId'),
-                    gmail_thread_id=composio_email.get('threadId'),
+                    thread_id=composio_email.get('thread_id'),
+                    gmail_thread_id=composio_email.get('thread_id'),
                     subject=composio_email.get('subject'),
                     from_email={'email': composio_email.get('from', {}).get('email', ''), 
                               'name': composio_email.get('from', {}).get('name', '')},
@@ -211,7 +211,7 @@ class TestEmailCountVerification:
         for i in range(expected_count):
             test_emails.append({
                 'messageId': f'conv_test_email_{i}',
-                'threadId': 'conv_thread_123',
+                'thread_id': 'conv_thread_123',
                 'subject': f'Conversation Test Email {i}',
                 'messageText': f'Conversation content {i}',
                 'date': str(1640995200 + i),
@@ -274,7 +274,7 @@ class TestEmailCountVerification:
         duplicate_emails = [
             {
                 'messageId': 'duplicate_email_123',
-                'threadId': 'thread_dup',
+                'thread_id': 'thread_dup',
                 'subject': 'Duplicate Email',
                 'messageText': 'First version',
                 'date': '1640995200',
@@ -285,7 +285,7 @@ class TestEmailCountVerification:
             },
             {
                 'messageId': 'duplicate_email_123',  # Same ID!
-                'threadId': 'thread_dup',
+                'thread_id': 'thread_dup',
                 'subject': 'Duplicate Email Updated',
                 'messageText': 'Second version',
                 'date': '1640995300',
@@ -318,8 +318,8 @@ class TestEmailCountVerification:
             for composio_email in messages_data:
                 email_doc = Email(
                     email_id=composio_email.get('messageId'),
-                    thread_id=composio_email.get('threadId'),
-                    gmail_thread_id=composio_email.get('threadId'),
+                    thread_id=composio_email.get('thread_id'),
+                    gmail_thread_id=composio_email.get('thread_id'),
                     subject=composio_email.get('subject'),
                     from_email={'email': composio_email.get('from', {}).get('email', ''), 
                               'name': composio_email.get('from', {}).get('name', '')},

--- a/backend/tests/test_email_data_processing_regression.py
+++ b/backend/tests/test_email_data_processing_regression.py
@@ -49,7 +49,7 @@ class TestEmailDataStructureRegression:
                     'messages': [
                         {
                             'messageId': '198efca4a33ef48d',
-                            'threadId': 'thread_123',
+                            'thread_id': 'thread_123',
                             'subject': 'Test Email Subject',
                             'messageText': 'Test email content',
                             'date': '1640995200',

--- a/backend/tests/test_email_integration_flow.py
+++ b/backend/tests/test_email_integration_flow.py
@@ -45,7 +45,7 @@ class TestEmailIntegrationFlow:
         expected_emails = [
             {
                 'messageId': 'integration_email_1',
-                'threadId': 'email_thread_1',
+                'thread_id': 'email_thread_1',
                 'subject': 'Integration Test Email 1',
                 'messageText': 'This is integration test email 1',
                 'date': '1640995200',
@@ -56,7 +56,7 @@ class TestEmailIntegrationFlow:
             },
             {
                 'messageId': 'integration_email_2', 
-                'threadId': 'email_thread_2',
+                'thread_id': 'email_thread_2',
                 'subject': 'Integration Test Email 2',
                 'messageText': 'This is integration test email 2',
                 'date': '1640995300',
@@ -111,7 +111,7 @@ class TestEmailIntegrationFlow:
                 
                 for composio_email in messages_data:
                     email_id = composio_email.get('messageId')
-                    thread_id = composio_email.get('threadId')
+                    thread_id = composio_email.get('thread_id')
                     subject = composio_email.get('subject', 'No Subject')
                     
                     # Parse from email
@@ -135,7 +135,7 @@ class TestEmailIntegrationFlow:
                     email_doc = Email(
                         email_id=email_id,
                         thread_id=thread_id,
-                        gmail_thread_id=composio_email.get('threadId'),
+                        gmail_thread_id=composio_email.get('thread_id'),
                         subject=subject,
                         from_email=from_email,
                         to_emails=to_emails,
@@ -260,7 +260,7 @@ class TestEmailIntegrationFlow:
         for i in range(large_batch_size):
             large_email_batch.append({
                 'messageId': f'perf_email_{i:04d}',
-                'threadId': f'perf_thread_{i:04d}',
+                'thread_id': f'perf_thread_{i:04d}',
                 'subject': f'Performance Test Email {i:04d}',
                 'messageText': f'Performance test content {i:04d}',
                 'date': str(1640995200 + i),
@@ -297,8 +297,8 @@ class TestEmailIntegrationFlow:
                 for composio_email in messages_data:
                     email_doc = Email(
                         email_id=composio_email.get('messageId'),
-                        thread_id=composio_email.get('threadId'),
-                        gmail_thread_id=composio_email.get('threadId'),
+                        thread_id=composio_email.get('thread_id'),
+                        gmail_thread_id=composio_email.get('thread_id'),
                         subject=composio_email.get('subject'),
                         from_email={'email': composio_email.get('from', {}).get('email', ''), 
                                   'name': composio_email.get('from', {}).get('name', '')},
@@ -332,7 +332,7 @@ class TestEmailIntegrationFlow:
         test_emails = [
             {
                 'messageId': 'concurrent_email_1',
-                'threadId': 'concurrent_thread_1',
+                'thread_id': 'concurrent_thread_1',
                 'subject': 'Concurrent Test Email 1',
                 'messageText': 'Concurrent test content 1',
                 'date': '1640995200',
@@ -361,8 +361,8 @@ class TestEmailIntegrationFlow:
         for i in range(5):
             email_doc = Email(
                 email_id=email_data.get('messageId'),
-                thread_id=email_data.get('threadId'),
-                gmail_thread_id=email_data.get('threadId'),
+                thread_id=email_data.get('thread_id'),
+                gmail_thread_id=email_data.get('thread_id'),
                 subject=f"{email_data.get('subject')} - Save {i}",  # Slightly different each time
                 from_email={'email': email_data.get('from', {}).get('email', ''), 
                           'name': email_data.get('from', {}).get('name', '')},


### PR DESCRIPTION
- Fix thread ID extraction in app.py to use 'thread_id' instead of 'threadId'
- Add fallback compatibility for both field names
- Update all test mock data to use correct 'thread_id' field name
- Update test code to extract thread IDs using correct field name
- Resolves issue where gmail_thread_id was being saved as null

This fixes the email threading feature that was not working due to incorrect field mapping between Composio API response and application code.