### PR TITLE
Add conversation cleanup functionality for tests

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -294,4 +294,53 @@ class Conversation:
             return result
         except Exception as e:
             print(f"Error in find_one: {str(e)}")
-            return None 
+            return None
+
+    @classmethod
+    def delete_by_thread_id(cls, thread_id):
+        """
+        Delete all conversations in a thread by thread_id.
+        
+        Args:
+            thread_id (str): The thread ID to delete all conversations for
+            
+        Returns:
+            int: Number of conversations deleted
+        """
+        try:
+            collection = get_collection(CONVERSATIONS_COLLECTION)
+            result = collection.delete_many({'thread_id': thread_id})
+            print(f"[DEBUG] Deleted {result.deleted_count} conversations for thread_id: {thread_id}")
+            return result.deleted_count
+        except Exception as e:
+            print(f"Error deleting conversations for thread_id {thread_id}: {str(e)}")
+            return 0
+
+    @classmethod
+    def delete_test_conversations(cls):
+        """
+        Delete all conversations that appear to be from tests (contain 'test' in thread_id).
+        This is a cleanup method for test environments.
+        
+        Returns:
+            int: Number of conversations deleted
+        """
+        try:
+            collection = get_collection(CONVERSATIONS_COLLECTION)
+            # Delete conversations with thread_ids containing 'test', 'integration', 'e2e', etc.
+            test_patterns = ['test', 'integration', 'e2e', 'workflow', 'sample']
+            total_deleted = 0
+            
+            for pattern in test_patterns:
+                result = collection.delete_many({
+                    'thread_id': {'$regex': pattern, '$options': 'i'}
+                })
+                total_deleted += result.deleted_count
+                if result.deleted_count > 0:
+                    print(f"[DEBUG] Deleted {result.deleted_count} conversations matching pattern: {pattern}")
+            
+            print(f"[DEBUG] Total test conversations deleted: {total_deleted}")
+            return total_deleted
+        except Exception as e:
+            print(f"Error deleting test conversations: {str(e)}")
+            return 0 

--- a/backend/tests/README_CONVERSATION_CLEANUP.md
+++ b/backend/tests/README_CONVERSATION_CLEANUP.md
@@ -1,0 +1,255 @@
+# Conversation Cleanup for Tests
+
+This document explains how to use the new conversation cleanup functionality to prevent test conversations from cluttering your database.
+
+## Problem
+
+Previously, tests that created `Conversation` objects would leave them in the database after the test completed, leading to:
+- Cluttered conversation lists in the UI
+- Database bloat over time
+- Potential test interference
+
+## Solution
+
+We've added comprehensive conversation cleanup functionality with multiple levels of protection:
+
+### 1. Individual Test Cleanup (`conversation_cleanup` fixture)
+
+Use this fixture in tests that create conversations to automatically clean them up after the test.
+
+```python
+def test_my_feature(self, test_db, clean_collections, conversation_cleanup):
+    """Test that creates conversations"""
+    # Track thread_id for cleanup
+    test_thread_id = 'my_test_thread_123'
+    conversation_cleanup(test_thread_id)
+    
+    # Create conversation
+    conversation = Conversation(
+        thread_id=test_thread_id,
+        role='assistant',
+        content='Test conversation'
+    )
+    conversation.save()
+    
+    # Test logic here...
+    # Conversation will be automatically deleted after test
+```
+
+### 2. Session-Level Cleanup (`cleanup_all_test_conversations` fixture)
+
+This fixture automatically runs at the end of the entire test session and removes any conversations with thread_ids containing test-related keywords:
+- `test`
+- `integration`
+- `e2e`
+- `workflow`
+- `sample`
+
+This provides a safety net in case individual tests don't use the `conversation_cleanup` fixture.
+
+### 3. Manual Cleanup Methods
+
+The `Conversation` model now includes cleanup methods:
+
+```python
+# Delete all conversations in a specific thread
+deleted_count = Conversation.delete_by_thread_id('my_thread_123')
+
+# Delete all test conversations (bulk cleanup)
+deleted_count = Conversation.delete_test_conversations()
+```
+
+## Usage Examples
+
+### Basic Usage
+
+```python
+def test_calendar_feature(self, test_db, clean_collections, conversation_cleanup):
+    """Basic usage example"""
+    # Track thread for cleanup
+    thread_id = 'calendar_test_123'
+    conversation_cleanup(thread_id)
+    
+    # Create conversation
+    conversation = Conversation(
+        thread_id=thread_id,
+        role='assistant',
+        content='Calendar test'
+    )
+    conversation.save()
+    
+    # Your test logic here...
+```
+
+### Multiple Conversations
+
+```python
+def test_multiple_conversations(self, test_db, clean_collections, conversation_cleanup):
+    """Track multiple conversations for cleanup"""
+    thread_ids = ['test_1', 'test_2', 'test_3']
+    
+    # Track all threads
+    for thread_id in thread_ids:
+        conversation_cleanup(thread_id)
+    
+    # Create multiple conversations
+    for thread_id in thread_ids:
+        conversation = Conversation(thread_id=thread_id, role='assistant', content='Test')
+        conversation.save()
+    
+    # All will be cleaned up automatically
+```
+
+### Dynamic Thread IDs
+
+```python
+def test_dynamic_threads(self, test_db, clean_collections, conversation_cleanup):
+    """Use dynamic thread IDs"""
+    import time
+    
+    # Create dynamic thread ID
+    thread_id = f'dynamic_test_{int(time.time())}'
+    conversation_cleanup(thread_id)
+    
+    # Create conversation
+    conversation = Conversation(thread_id=thread_id, role='assistant', content='Dynamic test')
+    conversation.save()
+    
+    # Will be cleaned up automatically
+```
+
+## Best Practices
+
+### 1. Always Track Before Creating
+
+```python
+# ✅ GOOD: Track thread_id before creating conversation
+thread_id = 'my_test_123'
+conversation_cleanup(thread_id)
+
+conversation = Conversation(thread_id=thread_id, role='assistant', content='Test')
+conversation.save()
+```
+
+```python
+# ❌ BAD: Forgot to track thread_id
+conversation = Conversation(thread_id='my_test_123', role='assistant', content='Test')
+conversation.save()
+# This conversation won't be cleaned up!
+```
+
+### 2. Use Descriptive Thread IDs
+
+```python
+# ✅ GOOD: Descriptive thread IDs
+thread_id = 'test_calendar_deletion_integration_123'
+conversation_cleanup(thread_id)
+```
+
+```python
+# ❌ BAD: Generic thread IDs
+thread_id = 'test123'
+conversation_cleanup(thread_id)
+```
+
+### 3. Combine with Existing Fixtures
+
+```python
+# ✅ GOOD: Use both cleanup fixtures
+def test_feature(self, test_db, clean_collections, conversation_cleanup):
+    # clean_collections: Cleans all collections before/after test
+    # conversation_cleanup: Tracks and cleans specific conversations
+    pass
+```
+
+### 4. Handle Nonexistent Threads Gracefully
+
+```python
+# ✅ GOOD: Cleanup handles nonexistent threads gracefully
+thread_id = 'nonexistent_thread_123'
+conversation_cleanup(thread_id)  # No error if thread doesn't exist
+```
+
+## Migration Guide
+
+### For Existing Tests
+
+1. Add `conversation_cleanup` parameter to test methods that create conversations
+2. Call `conversation_cleanup(thread_id)` before creating conversations
+3. Use descriptive thread IDs
+
+### Before (Old Way)
+```python
+def test_old_way(self, test_db, clean_collections):
+    conversation = Conversation(
+        thread_id='test_123',
+        role='assistant',
+        content='Test'
+    )
+    conversation.save()
+    # Conversation left in database!
+```
+
+### After (New Way)
+```python
+def test_new_way(self, test_db, clean_collections, conversation_cleanup):
+    thread_id = 'descriptive_test_123'
+    conversation_cleanup(thread_id)  # Track for cleanup
+    
+    conversation = Conversation(
+        thread_id=thread_id,
+        role='assistant',
+        content='Test'
+    )
+    conversation.save()
+    # Conversation automatically cleaned up!
+```
+
+## Files Modified
+
+- `backend/models/conversation.py` - Added cleanup methods
+- `backend/tests/conftest.py` - Added cleanup fixtures
+- `backend/tests/test_calendar_delete_integration.py` - Updated to use cleanup
+- `backend/tests/test_conversation_cleanup_example.py` - Example usage
+
+## Testing the Cleanup
+
+Run the example tests to verify cleanup is working:
+
+```bash
+cd backend
+python -m pytest tests/test_conversation_cleanup_example.py -v
+```
+
+You should see cleanup messages in the output:
+```
+[TEST CLEANUP] Deleted 1 conversations from 1 threads
+[SESSION CLEANUP] Deleted 0 test conversations
+```
+
+## Troubleshooting
+
+### Conversations Still Appearing
+
+1. Check if you're using the `conversation_cleanup` fixture
+2. Verify you're calling `conversation_cleanup(thread_id)` before creating conversations
+3. Check if thread_id contains test-related keywords (will be caught by session cleanup)
+
+### Cleanup Not Working
+
+1. Verify the test is using the `test_db` fixture
+2. Check that MongoDB is running and accessible
+3. Look for error messages in test output
+
+### Performance Issues
+
+1. The session cleanup runs once at the end of all tests
+2. Individual test cleanup is very fast
+3. If you have many test conversations, consider running `Conversation.delete_test_conversations()` manually
+
+## Future Improvements
+
+- Add automatic cleanup for other test data types (emails, etc.)
+- Add cleanup statistics reporting
+- Add cleanup verification tests
+- Consider adding cleanup to CI/CD pipeline

--- a/backend/tests/test_calendar_delete_integration.py
+++ b/backend/tests/test_calendar_delete_integration.py
@@ -26,14 +26,18 @@ os.environ["CI"] = "true"
 class TestCalendarDeleteIntegration:
     """Integration tests for calendar event deletion endpoint"""
     
-    def test_delete_calendar_event_success(self, test_db, clean_collections, mock_openai_client):
+    def test_delete_calendar_event_success(self, test_db, clean_collections, mock_openai_client, conversation_cleanup):
         """Test successful calendar event deletion through HTTP endpoint"""
         from app import app
         from models.conversation import Conversation
         
+        # Track this thread for cleanup
+        test_thread_id = 'test_thread_123'
+        conversation_cleanup(test_thread_id)
+        
         # Create a test conversation with calendar events
         conversation = Conversation(
-            thread_id='test_thread_123',
+            thread_id=test_thread_id,
             role='assistant',
             content='Here are your calendar events',
             tool_results={
@@ -78,14 +82,18 @@ class TestCalendarDeleteIntegration:
                 updated_conversation = Conversation.find_one({'thread_id': 'test_thread_123'})
                 assert len(updated_conversation['tool_results']['calendar_events']) == 0
     
-    def test_delete_calendar_event_not_found_in_conversation(self, test_db, clean_collections):
+    def test_delete_calendar_event_not_found_in_conversation(self, test_db, clean_collections, conversation_cleanup):
         """Test deletion when event is not found in conversation"""
         from app import app
         from models.conversation import Conversation
         
+        # Track this thread for cleanup
+        test_thread_id = 'test_thread_123'
+        conversation_cleanup(test_thread_id)
+        
         # Create a test conversation without the target event
         conversation = Conversation(
-            thread_id='test_thread_123',
+            thread_id=test_thread_id,
             role='assistant',
             content='Here are your calendar events',
             tool_results={
@@ -117,15 +125,19 @@ class TestCalendarDeleteIntegration:
             assert data['success'] is False
             assert 'Event not found in conversation' in data['error']
     
-    def test_delete_calendar_event_conversation_not_found(self, test_db, clean_collections):
+    def test_delete_calendar_event_conversation_not_found(self, test_db, clean_collections, conversation_cleanup):
         """Test deletion when conversation is not found"""
         from app import app
+        
+        # Track this thread for cleanup (even though it won't exist)
+        test_thread_id = 'nonexistent_thread_123'
+        conversation_cleanup(test_thread_id)
         
         with app.test_client() as client:
             response = client.post('/delete_calendar_event', 
                 json={
                     'event_id': 'test_event_789',
-                    'thread_id': 'nonexistent_thread_123',
+                    'thread_id': test_thread_id,
                     'message_id': 'test_message_456'
                 },
                 content_type='application/json'
@@ -170,14 +182,18 @@ class TestCalendarDeleteIntegration:
             assert data['success'] is False
             assert 'Missing required parameters' in data['error']
     
-    def test_delete_calendar_event_composio_failure(self, test_db, clean_collections):
+    def test_delete_calendar_event_composio_failure(self, test_db, clean_collections, conversation_cleanup):
         """Test deletion when Composio service fails"""
         from app import app
         from models.conversation import Conversation
         
+        # Track this thread for cleanup
+        test_thread_id = 'test_thread_123'
+        conversation_cleanup(test_thread_id)
+        
         # Create a test conversation with calendar events
         conversation = Conversation(
-            thread_id='test_thread_123',
+            thread_id=test_thread_id,
             role='assistant',
             content='Here are your calendar events',
             tool_results={
@@ -219,14 +235,18 @@ class TestCalendarDeleteIntegration:
                 updated_conversation = Conversation.find_one({'thread_id': 'test_thread_123'})
                 assert len(updated_conversation['tool_results']['calendar_events']) == 0
     
-    def test_delete_calendar_event_no_calendar_events(self, test_db, clean_collections):
+    def test_delete_calendar_event_no_calendar_events(self, test_db, clean_collections, conversation_cleanup):
         """Test deletion when conversation has no calendar events"""
         from app import app
         from models.conversation import Conversation
         
+        # Track this thread for cleanup
+        test_thread_id = 'test_thread_123'
+        conversation_cleanup(test_thread_id)
+        
         # Create a test conversation without calendar events
         conversation = Conversation(
-            thread_id='test_thread_123',
+            thread_id=test_thread_id,
             role='assistant',
             content='No calendar events here',
             tool_results={}

--- a/backend/tests/test_calendar_edge_cases.py
+++ b/backend/tests/test_calendar_edge_cases.py
@@ -86,7 +86,7 @@ class TestCalendarEdgeCases:
                 assert 'not connected' in response_data['response'].lower()
                 
     def test_composio_rate_limiting(
-        self, test_db, clean_collections, mock_openai_client, mock_composio_calendar_errors  
+        self, test_db, clean_collections, mock_openai_client, mock_composio_calendar_errors
     ):
         """Test handling of Composio API rate limiting"""
         from app import app

--- a/backend/tests/test_conversation_cleanup_example.py
+++ b/backend/tests/test_conversation_cleanup_example.py
@@ -1,0 +1,164 @@
+"""
+Example test file demonstrating how to use the conversation cleanup fixtures.
+
+This file shows the proper way to use the conversation_cleanup fixture
+to ensure test conversations are properly cleaned up after each test.
+"""
+
+import pytest
+from models.conversation import Conversation
+
+
+class TestConversationCleanupExample:
+    """Example tests showing proper conversation cleanup usage"""
+    
+    def test_create_conversation_with_cleanup(self, test_db, clean_collections, conversation_cleanup):
+        """Example: Create a conversation and track it for cleanup"""
+        # Track the thread_id for cleanup
+        test_thread_id = 'example_test_thread_123'
+        conversation_cleanup(test_thread_id)
+        
+        # Create a test conversation
+        conversation = Conversation(
+            thread_id=test_thread_id,
+            role='assistant',
+            content='This is a test conversation',
+            tool_results={'test_data': 'example'}
+        )
+        conversation.save()
+        
+        # Verify conversation was created
+        saved_conversation = Conversation.find_one({'thread_id': test_thread_id})
+        assert saved_conversation is not None
+        assert saved_conversation['content'] == 'This is a test conversation'
+        
+        # The conversation will be automatically cleaned up after the test
+    
+    def test_create_multiple_conversations_with_cleanup(self, test_db, clean_collections, conversation_cleanup):
+        """Example: Create multiple conversations and track them all for cleanup"""
+        thread_ids = ['multi_test_1', 'multi_test_2', 'multi_test_3']
+        
+        # Track all thread_ids for cleanup
+        for thread_id in thread_ids:
+            conversation_cleanup(thread_id)
+        
+        # Create multiple test conversations
+        for i, thread_id in enumerate(thread_ids):
+            conversation = Conversation(
+                thread_id=thread_id,
+                role='assistant',
+                content=f'Test conversation {i+1}',
+                tool_results={'test_index': i}
+            )
+            conversation.save()
+        
+        # Verify all conversations were created
+        for i, thread_id in enumerate(thread_ids):
+            saved_conversation = Conversation.find_one({'thread_id': thread_id})
+            assert saved_conversation is not None
+            assert saved_conversation['content'] == f'Test conversation {i+1}'
+        
+        # All conversations will be automatically cleaned up after the test
+    
+    def test_conversation_cleanup_handles_nonexistent_threads(self, test_db, clean_collections, conversation_cleanup):
+        """Example: Cleanup fixture handles nonexistent threads gracefully"""
+        # Track a thread that doesn't exist
+        nonexistent_thread_id = 'nonexistent_thread_456'
+        conversation_cleanup(nonexistent_thread_id)
+        
+        # Try to find the nonexistent conversation
+        conversation = Conversation.find_one({'thread_id': nonexistent_thread_id})
+        assert conversation is None
+        
+        # Cleanup will handle this gracefully (no error)
+    
+    def test_conversation_cleanup_with_dynamic_thread_ids(self, test_db, clean_collections, conversation_cleanup):
+        """Example: Use dynamic thread IDs and track them for cleanup"""
+        import time
+        
+        # Create dynamic thread IDs
+        timestamp = int(time.time())
+        thread_ids = [
+            f'dynamic_test_{timestamp}_1',
+            f'dynamic_test_{timestamp}_2'
+        ]
+        
+        # Track all dynamic thread_ids for cleanup
+        for thread_id in thread_ids:
+            conversation_cleanup(thread_id)
+        
+        # Create conversations with dynamic IDs
+        for i, thread_id in enumerate(thread_ids):
+            conversation = Conversation(
+                thread_id=thread_id,
+                role='assistant',
+                content=f'Dynamic test conversation {i+1}',
+                tool_results={'timestamp': timestamp, 'index': i}
+            )
+            conversation.save()
+        
+        # Verify conversations were created
+        for i, thread_id in enumerate(thread_ids):
+            saved_conversation = Conversation.find_one({'thread_id': thread_id})
+            assert saved_conversation is not None
+            assert saved_conversation['content'] == f'Dynamic test conversation {i+1}'
+        
+        # All dynamic conversations will be automatically cleaned up after the test
+
+
+class TestConversationCleanupBestPractices:
+    """Best practices for using conversation cleanup in tests"""
+    
+    def test_always_track_thread_ids_before_creating_conversations(self, test_db, clean_collections, conversation_cleanup):
+        """Best Practice: Always track thread_ids before creating conversations"""
+        # ✅ GOOD: Track thread_id before creating conversation
+        test_thread_id = 'best_practice_thread_123'
+        conversation_cleanup(test_thread_id)
+        
+        conversation = Conversation(
+            thread_id=test_thread_id,
+            role='assistant',
+            content='Best practice conversation'
+        )
+        conversation.save()
+        
+        # Verify it was created
+        saved_conversation = Conversation.find_one({'thread_id': test_thread_id})
+        assert saved_conversation is not None
+    
+    def test_use_descriptive_thread_ids(self, test_db, clean_collections, conversation_cleanup):
+        """Best Practice: Use descriptive thread IDs that clearly indicate they're test data"""
+        # ✅ GOOD: Descriptive thread IDs
+        test_thread_id = 'test_calendar_deletion_integration_123'
+        conversation_cleanup(test_thread_id)
+        
+        conversation = Conversation(
+            thread_id=test_thread_id,
+            role='assistant',
+            content='Descriptive thread ID conversation'
+        )
+        conversation.save()
+        
+        # Verify it was created
+        saved_conversation = Conversation.find_one({'thread_id': test_thread_id})
+        assert saved_conversation is not None
+    
+    def test_cleanup_works_with_existing_clean_collections_fixture(self, test_db, clean_collections, conversation_cleanup):
+        """Best Practice: Use both clean_collections and conversation_cleanup fixtures together"""
+        # Both fixtures work together:
+        # - clean_collections: Cleans all collections before/after test
+        # - conversation_cleanup: Tracks and cleans specific conversations
+        
+        test_thread_id = 'combined_fixtures_test_123'
+        conversation_cleanup(test_thread_id)
+        
+        conversation = Conversation(
+            thread_id=test_thread_id,
+            role='assistant',
+            content='Combined fixtures test'
+        )
+        conversation.save()
+        
+        # Verify it was created
+        saved_conversation = Conversation.find_one({'thread_id': test_thread_id})
+        assert saved_conversation is not None


### PR DESCRIPTION
- Add delete_by_thread_id() and delete_test_conversations() methods to Conversation model
- Add conversation_cleanup fixture for individual test cleanup
- Add cleanup_all_test_conversations fixture for session-wide cleanup
- Update calendar delete integration tests to use cleanup fixtures
- Add comprehensive documentation and examples for cleanup functionality
- Remove skip decorators from tests (will work when API quota renews)

This solves the issue of test spam in conversations database by automatically cleaning up test-generated conversations after each test and at session end.